### PR TITLE
553632 init build infrastructure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    java
+    kotlin("jvm") version "1.3.61"
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+}
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}
+
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}

--- a/incoming/build.gradle.kts
+++ b/incoming/build.gradle.kts
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+plugins {
+    java
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+}

--- a/incoming/org.eclipse.passage.lic.base/build.gradle.kts
+++ b/incoming/org.eclipse.passage.lic.base/build.gradle.kts
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+plugins {
+    java
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(project(":incoming:org.eclipse.passage.lic.api"))
+}

--- a/ps-access/build.gradle.kts
+++ b/ps-access/build.gradle.kts
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    java
+    kotlin("jvm")
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(project(":incoming:org.eclipse.passage.lic.api"))
+    implementation(project(":incoming:org.eclipse.passage.lic.base"))
+    implementation(kotlin("stdlib-jdk8"))
+}
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}
+
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}

--- a/ps-dev/build.gradle.kts
+++ b/ps-dev/build.gradle.kts
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    java
+    kotlin("jvm")
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(project(":incoming"))
+    implementation(kotlin("stdlib-jdk8"))
+}
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}
+
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = "1.8"
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+rootProject.name = "passage-spring"
+include(
+        "incoming:org.eclipse.passage.lic.api",
+        "incoming:org.eclipse.passage.lic.base",
+        "ps-access",
+        "ps-dev")


### PR DESCRIPTION
 1. Gradle (Kotlin DSL) is employed
 2.  build scripts are appended for the following projects structure 
      - ps-access [spring-based access cycle implementation]
      - ps-dev  [dev api based on spring]
      - incoming [temporary subproject for general passga source base involvement until [553630](https://bugs.eclipse.org/bugs/show_bug.cgi?id=553630) is fixed

Signed-off-by: elena.parovyshnaya <elena.parovyshnaya@gmail.com>