### PR TITLE
#553708	- implement spring-based AccessManager structure

### DIFF
--- a/outgoing/README.md
+++ b/outgoing/README.md
@@ -1,0 +1,13 @@
+Re-facilitation of access-cycle 
+ - causes multiple complains to the contemporary *passage lic.api* 
+ - requires additional interfaces to be designed under *lic.base*
+  
+Until the solution is finalized, 
+all suggestions to the original *passage codebase*
+ are going to settle here,  in temporary `outgoing` sub-projects. 
+ 
+Here are two parts:
+
+ - `lic.internal.api` for alternative public interfaces
+ - `lic.internal.base` for *Spring*-independent classes that are required 
+ for the current *Spring*-based implementation of *access cycle* 

--- a/outgoing/build.gradle.kts
+++ b/outgoing/build.gradle.kts
@@ -10,12 +10,13 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-rootProject.name = "passage-spring"
-include(
-        "incoming:org.eclipse.passage.lic.api",
-        "incoming:org.eclipse.passage.lic.base",
-        "ps-access",
-        "ps-dev",
-	"outgoing:org.eclipse.passage.lic.internal.api",
-	"outgoing:org.eclipse.passage.lic.internal.base",
-	"spring-client")
+plugins {
+    java
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+}

--- a/outgoing/org.eclipse.passage.lic.internal.api/build.gradle.kts
+++ b/outgoing/org.eclipse.passage.lic.internal.api/build.gradle.kts
@@ -10,12 +10,14 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-rootProject.name = "passage-spring"
-include(
-        "incoming:org.eclipse.passage.lic.api",
-        "incoming:org.eclipse.passage.lic.base",
-        "ps-access",
-        "ps-dev",
-	"outgoing:org.eclipse.passage.lic.internal.api",
-	"outgoing:org.eclipse.passage.lic.internal.base",
-	"spring-client")
+plugins {
+    java
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(project(":incoming:org.eclipse.passage.lic.api"))
+}

--- a/outgoing/org.eclipse.passage.lic.internal.api/src/main/java/org/eclipse/passage/lic/internal/api/requirements/RequirementResolverRegistry.java
+++ b/outgoing/org.eclipse.passage.lic.internal.api/src/main/java/org/eclipse/passage/lic/internal/api/requirements/RequirementResolverRegistry.java
@@ -10,12 +10,11 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-rootProject.name = "passage-spring"
-include(
-        "incoming:org.eclipse.passage.lic.api",
-        "incoming:org.eclipse.passage.lic.base",
-        "ps-access",
-        "ps-dev",
-	"outgoing:org.eclipse.passage.lic.internal.api",
-	"outgoing:org.eclipse.passage.lic.internal.base",
-	"spring-client")
+package org.eclipse.passage.lic.internal.api.requirements;
+
+import org.eclipse.passage.lic.api.requirements.RequirementResolver;
+
+public interface RequirementResolverRegistry {
+
+	Iterable<RequirementResolver> resolvers();
+}

--- a/outgoing/org.eclipse.passage.lic.internal.api/src/main/java/org/eclipse/passage/lic/internal/api/restrictions/RestrictionExecutorRegistry.java
+++ b/outgoing/org.eclipse.passage.lic.internal.api/src/main/java/org/eclipse/passage/lic/internal/api/restrictions/RestrictionExecutorRegistry.java
@@ -10,12 +10,12 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-rootProject.name = "passage-spring"
-include(
-        "incoming:org.eclipse.passage.lic.api",
-        "incoming:org.eclipse.passage.lic.base",
-        "ps-access",
-        "ps-dev",
-	"outgoing:org.eclipse.passage.lic.internal.api",
-	"outgoing:org.eclipse.passage.lic.internal.base",
-	"spring-client")
+package org.eclipse.passage.lic.internal.api.restrictions;
+
+import org.eclipse.passage.lic.api.restrictions.RestrictionExecutor;
+
+public interface RestrictionExecutorRegistry {
+
+	Iterable<RestrictionExecutor> executors();
+
+}

--- a/outgoing/org.eclipse.passage.lic.internal.base/build.gradle.kts
+++ b/outgoing/org.eclipse.passage.lic.internal.base/build.gradle.kts
@@ -10,12 +10,15 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-rootProject.name = "passage-spring"
-include(
-        "incoming:org.eclipse.passage.lic.api",
-        "incoming:org.eclipse.passage.lic.base",
-        "ps-access",
-        "ps-dev",
-	"outgoing:org.eclipse.passage.lic.internal.api",
-	"outgoing:org.eclipse.passage.lic.internal.base",
-	"spring-client")
+plugins {
+    java
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    implementation(project(":outgoing:org.eclipse.passage.lic.internal.api"))
+    implementation(project(":incoming:org.eclipse.passage.lic.base"))
+}

--- a/outgoing/org.eclipse.passage.lic.internal.base/src/main/java/org/eclipse/passage/lic/internal/base/access/ConditionTypeProperty.java
+++ b/outgoing/org.eclipse.passage.lic.internal.base/src/main/java/org/eclipse/passage/lic/internal/base/access/ConditionTypeProperty.java
@@ -10,12 +10,23 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-rootProject.name = "passage-spring"
-include(
-        "incoming:org.eclipse.passage.lic.api",
-        "incoming:org.eclipse.passage.lic.base",
-        "ps-access",
-        "ps-dev",
-	"outgoing:org.eclipse.passage.lic.internal.api",
-	"outgoing:org.eclipse.passage.lic.internal.base",
-	"spring-client")
+package org.eclipse.passage.lic.internal.base.access;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.passage.lic.base.LicensingProperties;
+
+public class ConditionTypeProperty {
+	private final String type;
+
+	public ConditionTypeProperty(String type) {
+		this.type = type;
+	}
+
+	public Map<String, Object> map() {
+		Map<String, Object> properties = new HashMap<>();
+		properties.put(LicensingProperties.LICENSING_CONDITION_TYPE_ID, type);
+		return properties;
+	}
+}


### PR DESCRIPTION
Re-facilitation of access-cycle causes multiple complains to the contemporary passage lic.api and requires additional interfaces to be designed under lic.base. Until the solution is finalized, all suggestions to the original passage code are going to be formed in `outgoing` sub-projects. 

Added to *api*: 
 - `RequirementResolverRegistry` interface as there is no such a registry against the common passage atchtecture pattern
 - `RestrictionExecutorRegistry` as the original one from *incoming* `lic.api.restrictions` package does not do executor's registration and those executor are bound to access manager one by one.

Added to *base*: 
 - `ConditionTypeProperty` which adapts *condition type* to map - this is the only valuable property for a `ConditionMiner` registration in proper registry.

Signed-off-by: Elena Parovyshnaia <elena.parovyshnaya@gmail.com>