### PR TITLE
#553876 implement event bus

### DIFF
--- a/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/access/AccessManager.kt
+++ b/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/access/AccessManager.kt
@@ -18,21 +18,25 @@ import org.eclipse.passage.lic.internal.api.requirements.RequirementResolverRegi
 import org.eclipse.passage.lic.internal.api.restrictions.RestrictionExecutorRegistry
 import org.eclipse.passage.lic.base.access.BaseAccessManager
 import org.eclipse.passage.lic.internal.base.access.ConditionTypeProperty
+import org.eclipse.passage.lic.spring.event.Publisher
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
 
-
 @Component
+@Primary
 class AccessManager @Autowired constructor(
         private val conditionMiners: ConditionMinerRegistry,
         private val permissionEmitters: PermissionEmitterRegistry,
         private val requirementResolvers: RequirementResolverRegistry,
-        private val restrictionExecutors: RestrictionExecutorRegistry) : BaseAccessManager() {
+        private val restrictionExecutors: RestrictionExecutorRegistry,
+        private val eventPublisher: Publisher) : BaseAccessManager() {
     init {
         pullConditionMinerRegistry()
         pullPermissionEmitters()
         pullRequirementResolvers()
         pullRestrictionExecutors()
+        pullPublisher()
     }
 
     private fun pullConditionMinerRegistry() = super.bindConditionMinerRegistry(conditionMiners)
@@ -48,5 +52,7 @@ class AccessManager @Autowired constructor(
 
     private fun pullRestrictionExecutors() =
             restrictionExecutors.executors().forEach { super.bindRestrictionExecutor(it) }
+
+    private fun pullPublisher() = super.bindLicensingReporter(eventPublisher)
 
 }

--- a/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/event/AccessCycleEvent.kt
+++ b/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/event/AccessCycleEvent.kt
@@ -10,10 +10,16 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.spring.access
+package org.eclipse.passage.lic.spring.event
 
-import org.springframework.context.annotation.ComponentScan
+import org.eclipse.passage.lic.api.LicensingEvents
+import org.eclipse.passage.lic.api.LicensingResult
+import org.springframework.context.ApplicationEvent
 
-@ComponentScan("org.eclipse.passage.lic.spring")
-open class TestConfig { // spring configuration cannot be final
+class AccessCycleEvent(private val origin: LicensingResult) : ApplicationEvent(origin.source) {
+
+    fun topic() = origin.getAttachment(LicensingEvents.PROPERTY_TOPIC)
+
+    fun data() = origin.getAttachment(LicensingEvents.PROPERTY_DATA)
+
 }

--- a/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/event/Listener.kt
+++ b/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/event/Listener.kt
@@ -10,10 +10,8 @@
  * Contributors:
  *     ArSysOp - initial API and implementation
  *******************************************************************************/
-package org.eclipse.passage.lic.spring.access
+package org.eclipse.passage.lic.spring.event
 
-import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.ApplicationListener
 
-@ComponentScan("org.eclipse.passage.lic.spring")
-open class TestConfig { // spring configuration cannot be final
-}
+interface Listener : ApplicationListener<AccessCycleEvent>

--- a/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/event/Publisher.kt
+++ b/ps-access/src/main/kotlin/org/eclipse/passage/lic/spring/event/Publisher.kt
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     ArSysOp - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.passage.lic.spring.event
+
+import org.eclipse.passage.lic.api.LicensingReporter
+import org.eclipse.passage.lic.api.LicensingResult
+import org.eclipse.passage.lic.base.SystemReporter
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Primary
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+@Primary
+class Publisher @Autowired constructor(private val publisher: ApplicationEventPublisher) : LicensingReporter {
+    //val logger: Logger TODO: #553877
+
+    @Async
+    override fun postResult(result: LicensingResult) {
+        sendResult(result)
+    }
+
+    override fun logResult(result: LicensingResult) {
+        SystemReporter.INSTANCE.logResult(result) //  TODO: #553877
+    }
+
+    override fun sendResult(result: LicensingResult) {
+        publisher.publishEvent(AccessCycleEvent(result))
+    }
+
+}


### PR DESCRIPTION
Event Bus
- base access event is implemented in `AccessCycleEvent`
- event sending is available by primary bean `Publisher`
- event subscription can be achieved by implementing `Listener`

And Spring-based AccessManager is equipped with the `Publisher` and can deal with events now.

Signed-off-by: Elena Parovyshnaia <elena.parovyshnaya@gmail.com>