### PR TITLE
#557991 - rework (facade) i18n machine in common passage bundles

### DIFF
--- a/incoming/org.eclipse.passage.lic.base/build.gradle.kts
+++ b/incoming/org.eclipse.passage.lic.base/build.gradle.kts
@@ -21,3 +21,10 @@ repositories {
 dependencies {
     implementation(project(":incoming:org.eclipse.passage.lic.api"))
 }
+
+// workaround for #557991 - [Passage] rework (facade) i18n machine in common passage bundles
+sourceSets.forEach{
+    it.resources{
+        srcDir(file("src/main/java"))
+    }
+}


### PR DESCRIPTION
  - include java sources to `resource` source set in order to get *.properties at runtime

Signed-off-by: Elena Parovyshnaia <elena.parovyshnaya@gmail.com>